### PR TITLE
Add extension trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,11 +64,49 @@ impl<S: Stream<Item = T> + Unpin, T, U: FnOnce() + Unpin> Drop for DropStream<S,
     }
 }
 
+pub trait DropStreamExt<U: FnOnce() + Unpin>: Stream + Unpin + Sized {
+    /// Wraps the stream with a closure that is called once it is dropped.
+    /// ex:
+    /// ```rust
+    /// use std::task::Poll;
+    /// use futures::{stream::repeat, Stream};
+    /// use drop_stream::DropStreamExt;
+    ///
+    /// fn main() {
+    ///     let some_stream = repeat(true);
+    ///
+    ///     let mut has_run = false;
+    ///     let has_run_ref = &mut has_run;
+    ///     let drop_stream = some_stream.on_drop(move || {
+    ///         *has_run_ref = true;
+    ///         println!("Stream has been dropped!")
+    ///     });
+    ///
+    ///     let mut drop_stream = Box::pin(drop_stream);
+    ///
+    ///     // Some stream work and polling...
+    ///
+    ///     drop(drop_stream); // Runs the closure
+    ///     assert!(has_run);
+    /// }
+    /// ```
+    fn on_drop(self, dropper: U) -> DropStream<Self, Self::Item, U>;
+}
+
+impl<T, U: FnOnce() + Unpin> DropStreamExt<U> for T
+where
+    T: Stream + Unpin + Sized,
+{
+    fn on_drop(self, dropper: U) -> DropStream<T, T::Item, U> {
+        DropStream::new(self, dropper)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::task::Poll;
 
-    use crate::DropStream;
+    use crate::{DropStream, DropStreamExt};
     use futures::{stream::repeat, Stream};
 
     #[test]
@@ -112,6 +150,31 @@ mod tests {
         {
             let has_run_ref = &mut has_run;
             let drop_stream = DropStream::new(test_stream, move || {
+                *has_run_ref = true;
+            });
+
+            let mut drop_stream = Box::pin(drop_stream);
+
+            let waker = futures::task::noop_waker();
+            let mut context = futures::task::Context::from_waker(&waker);
+            assert_eq!(
+                drop_stream.as_mut().poll_next(&mut context),
+                Poll::Ready(Some(true))
+            );
+        }
+
+        assert!(has_run)
+    }
+
+    #[test]
+    fn stream_trait_is_implemented() {
+        let test_stream = repeat(true);
+
+        let mut has_run = false;
+
+        {
+            let has_run_ref = &mut has_run;
+            let drop_stream = test_stream.on_drop(move || {
                 *has_run_ref = true;
             });
 


### PR DESCRIPTION
Added `DropStreamExt` (good enough name?) that adds a helper function `on_drop(...)` to all objects that implement `Stream`.

Makes it a little less verbose to construct a `DropStream` now :)

Additionally, might work better in method-chaining scenarios (like using `map` on  a `Stream` from `futures::stream::StreamExt`)

Ex (from function doc):
```rust
use std::task::Poll;
use futures::{stream::repeat, Stream};
use drop_stream::DropStreamExt;

fn main() {
    let some_stream = repeat(true);

    let mut has_run = false;
    let has_run_ref = &mut has_run;

    let drop_stream = some_stream.on_drop(move || {
        *has_run_ref = true;
        println!("Stream has been dropped!")
    });

    let mut drop_stream = Box::pin(drop_stream);

    // Some stream work and polling...

    drop(drop_stream); // Runs the closure

    assert!(has_run);
}
```

Hope this is helpful! Let me know if you have any comments or concerns :)